### PR TITLE
Proxy params

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/playlab/nginx:1.11.3
+FROM quay.io/playlab/nginx:1.11.6
 
 MAINTAINER Jason Wilder mail@jasonwilder.com # Original maintainer
 MAINTAINER Sebastian Sasu <sebastian.s@pocketplaylab.com> # This Fork's maintainer

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,9 @@ RUN echo "daemon off;" >> /etc/nginx/nginx.conf \
 ADD https://github.com/jwilder/forego/releases/download/v0.16.1/forego /usr/local/bin/forego
 RUN chmod u+x /usr/local/bin/forego
 
+# Add proxy parameters
+COPY proxy.conf /etc/nginx/proxy.conf
+
 ENV DOCKER_GEN_VERSION 0.7.3
 
 RUN wget https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \

--- a/proxy.conf
+++ b/proxy.conf
@@ -1,0 +1,13 @@
+# HTTP 1.1 support
+proxy_http_version 1.1;
+proxy_buffering off;
+proxy_set_header Host $http_host;
+proxy_set_header Upgrade $http_upgrade;
+proxy_set_header Connection $proxy_connection;
+proxy_set_header X-Real-IP $remote_addr;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_redirect off;
+proxy_read_timeout 300;
+proxy_send_timeout 300;


### PR DESCRIPTION
Using proxy parameters from file. Increased timeout limit to 300 seconds for `proxy_read_timeout` and `proxy_send_timeout`. Updated nginx to version 1.11.6